### PR TITLE
Optimising score calculations

### DIFF
--- a/minimalmarkers.py
+++ b/minimalmarkers.py
@@ -679,11 +679,11 @@ def _chunked_first_score_patterns(patterns, skip_patterns,
                 # We could instead have used numpy.bincount, but then
                 # we would have to recode or remove -1 values first.
                 bins[patterns[p, i]] += 1
+            # Examining the matrix we can see that the score can be calculated directly as:
+            score = bins[0] * bins[1] + (bins[0] + bins[1]) * bins[2]
+            # If we wanted to handle more than three groups this formula could be extended
             # We skip the invalid -1 code by ignoring the last bin value in this
             # calculation.
-            # Note that we divide by two here as we have calculated for the full
-            # matrix, but we only want to use half.
-            score = (_np.square(_np.sum(bins[:-1])) - _np.sum(_np.square(bins[:-1]))) // 2
             scores[p] = score
 
             if score == 0:

--- a/minimalmarkers.py
+++ b/minimalmarkers.py
@@ -727,13 +727,40 @@ def _first_score_patterns(patterns, skip_patterns,
     return scores
 
 
+@_numba.jit(nopython=True, cache=True)
+def _unmatched_element_indices(pattern, expected_size):
+    """Calculate the co-ordinates of the elements with value
+       zero in the matrix corresponding to the passed in pattern.
+       Returns
+       =======
+            indices : N x 2 numpy array containing row/column of each zero
+    """
+    indices = _np.empty((expected_size, 2), dtype=_np.int64)
+    nele: int = pattern.size
+    idx: int = 0 # shared across iterations, so can't parallelise the loops
+    for i in range(0, nele):
+        ival: int = pattern[i]
+        for j in range(0, i):
+            jval: int = pattern[j]
+            if ival == -1 or jval == -1 or ival == jval:
+                indices[idx, 0] = i
+                indices[idx, 1] = j
+                idx += 1
+
+    if idx != expected_size:
+        print(f'{idx} does not match expected number of elements ({expected_size})')
+
+    return indices
+
+
 @_numba.jit(nopython=True, nogil=True, fastmath=True,
             parallel=True, cache=True)
-def _chunked_rescore_patterns(patterns, matrix, skip_patterns,
+def _chunked_rescore_patterns(patterns, indices, skip_patterns,
                               scores, sorted_idxs,
                               best_score: int,
                               start: int, end: int):
     ncols: int = patterns.shape[1]
+    nidx: int = indices.shape[0]
 
     nthreads: int = _numba.config.NUMBA_NUM_THREADS
 
@@ -762,15 +789,13 @@ def _chunked_rescore_patterns(patterns, matrix, skip_patterns,
             # this pattern could be the best scoring pattern...
             score: int = 0
 
-            for i in range(0, ncols):
+            for idx in range(0, nidx):
+                i: int = indices[idx, 0]
+                j: int  = indices[idx, 1]
                 ival: int = patterns[p, i]
-
-                if ival != -1:
-                    for j in range(i+1, ncols):
-                        jval: int = patterns[p, j]
-
-                        score += (jval != -1 and ival != jval and
-                                  matrix[i, j] == 0)
+                jval: int = patterns[p, j]
+                if ival != -1 and jval != -1 and ival != jval:
+                    score += 1
 
             scores[p] = score
 
@@ -791,7 +816,7 @@ def _chunked_rescore_patterns(patterns, matrix, skip_patterns,
     return best_score
 
 
-def _rescore_patterns(patterns, matrix, skip_patterns, scores, sorted_idxs,
+def _rescore_patterns(patterns, indices, skip_patterns, scores, sorted_idxs,
                       print_progress: bool = False):
     """Do the work of scoring all of the passed patterns against
        the current value of the matrix. This returns a tuple
@@ -823,13 +848,41 @@ def _rescore_patterns(patterns, matrix, skip_patterns, scores, sorted_idxs,
                       unit="patterns", unit_scale=chunk_size):
         start: int = i * chunk_size
         end: int = min((i+1)*chunk_size, npatterns)
-        best_score: int = _chunked_rescore_patterns(patterns, matrix,
+        best_score: int = _chunked_rescore_patterns(patterns, indices,
                                                     skip_patterns,
                                                     scores, sorted_idxs,
                                                     best_score,
                                                     start, end)
 
     return _np.argsort(scores)[::-1]
+
+
+@_numba.jit(nopython=True, cache=True)
+def _remove_matched_indices(data, indices, num_fewer):
+    """Removes indices from the input array corresponding to
+       ones in the matrix generated from the data array
+       Returns
+       =======
+            new_indices : N x 2 numpy array containing the new indices
+    """
+    num_old: int = indices.shape[0]
+    new_size: int = num_old - num_fewer
+    nrows: int = data.shape[0]
+    new_indices = _np.empty((new_size, 2), dtype=_np.int64)
+    new_idx: int = 0 # shared accross iterations, so can't parallelise the loop
+    for old_idx in range(0, num_old):
+        i: int = indices[old_idx, 0]
+        j: int = indices[old_idx, 1]
+        ival: int = data[i]
+        jval: int = data[j]
+        if ival == -1 or jval == -1 or ival == jval:
+            new_indices[new_idx] = [i, j]
+            new_idx += 1
+
+    if new_idx != new_size:
+        print(f'{new_idx} does not match expected number of elements ({new_size})')
+
+    return new_indices
 
 
 @_numba.jit(nopython=True, fastmath=True, nogil=True,
@@ -1014,9 +1067,13 @@ def find_best_patterns(patterns: Patterns,
     scores[best_pattern] = 0
     skip_patterns[best_pattern] = 1
 
-    # create the matrix showing which varieties can be distinguished
-    matrix = _np.zeros((ncols, ncols), _np.int8)
-    matrix = _create_matrix(patterns.patterns[best_pattern], matrix)
+
+    # number of elements that can still distinguish varieties
+    nremain = perfect_score - best_score
+
+    # create a list indicies representing a sparse matrix containing the elements
+    # can be still be used to distinguish varieties
+    remaining_indices = _unmatched_element_indices(patterns.patterns[best_pattern], nremain)
 
     if print_progress:
         pattern = _get_pattern_from_array(patterns.patterns[best_pattern])
@@ -1033,7 +1090,7 @@ def find_best_patterns(patterns: Patterns,
     while current_score > 0:
         iteration += 1
 
-        sorted_idxs = _rescore_patterns(patterns.patterns, matrix,
+        sorted_idxs = _rescore_patterns(patterns.patterns, remaining_indices,
                                         skip_patterns, scores, sorted_idxs,
                                         print_progress)
 
@@ -1048,9 +1105,7 @@ def find_best_patterns(patterns: Patterns,
             scores[best_pattern] = 0
             skip_patterns[best_pattern] = 1
 
-            matrix += _create_matrix(patterns.patterns[best_pattern],
-                                     matrix)
-
+            remaining_indices = _remove_matched_indices(patterns.patterns[best_pattern], remaining_indices, best_score)
             if print_progress:
                 pattern = _get_pattern_from_array(
                                 patterns.patterns[best_pattern])

--- a/minimalmarkers.py
+++ b/minimalmarkers.py
@@ -747,8 +747,7 @@ def _unmatched_element_indices(pattern, expected_size):
                 indices[idx, 1] = j
                 idx += 1
 
-    if idx != expected_size:
-        print(f'{idx} does not match expected number of elements ({expected_size})')
+    assert(idx == expected_size)
 
     return indices
 

--- a/minimalmarkers.py
+++ b/minimalmarkers.py
@@ -878,8 +878,7 @@ def _remove_matched_indices(data, indices, num_fewer):
             new_indices[new_idx] = [i, j]
             new_idx += 1
 
-    if new_idx != new_size:
-        print(f'{new_idx} does not match expected number of elements ({new_size})')
+    assert(new_idx == new_size)
 
     return new_indices
 


### PR DESCRIPTION
These changes include two optimisations for calculating the score.

Firstly when creating the initial scores we are only matching one of three distinct value (0, 1, 2). It is therefore possible to think of the match matrix as a block-diagonal matrix with three blocks (we ignore the invalid values of -1), e.g.

0 0 1 1 1 1 1 1
0 0 1 1 1 1 1 1
1 1 0 0 0 1 1 1
1 1 0 0 0 1 1 1
1 1 0 0 0 1 1 1
1 1 1 1 1 0 0 0
1 1 1 1 1 0 0 0
1 1 1 1 1 0 0 0

Because of this we can avoid actually counting all of the matches and instead calculate the score as the area made up by the blocks of ones in either the upper or lower diagonal.

The second optimisation is possible when calculating the subsequent best matching scores. At each iteration we have a matrix indicating row/column pairs that have been matched by previous patterns, e.g.

0
1 1
0 0 1
0 1 0 1
1 1 1 1 1
0 0 0 1 0 0
1 0 1 1 1 1 0
1 1 1 0 0 0 1 1

At each iteration we calculate a new score for each pattern based on the number of "1" values in its matrix where there is a "0" in the matrix above. As the number of zeros in the above matrix is likely to be low, and decreases with each iteration we can avoid having to check each element if we use a sparse matrix representation to store only the co-ordinates of the elements that need to be checked.